### PR TITLE
Correct Conditional Entropy Formulation in Guide

### DIFF
--- a/docs/guide/cond_entropy/index.md
+++ b/docs/guide/cond_entropy/index.md
@@ -41,7 +41,7 @@ $$
 This local conditional entropy also satisfies the chain rule as its average counterparts, hence one can express the local conditional entropy as:
 
 $$
-h(x \mid y) = h(x,y) - h(x)
+h(x \mid y) = h(x,y) - h(y)
 $$
 
 Joint entropy can be accessed from the usual entropy an estimator interface.


### PR DESCRIPTION
Hi, I think the formulation contained a mistake, where variables Y and X were switched (see: Cover & Thomas, 2001, page 16). 

Theorem 2.2.1 (Chain rule): H(X, Y) = H(X) + H(Y|X)
H(X, Y) - H(X) = H(Y|X)
H(Y|X) = H(X, Y) - H(X)
H(X|Y) = H(Y, X) - H(Y)
H(X|Y) = H(X, Y) - H(Y)

but it was:
H(X|Y) = H(X,Y) - H(X)

Cover, T. M., & Thomas, J. A. (2001). Elements of information theory. Wiley-Interscience.