### PR TITLE
chore: Relax upper version constraints in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.22,<2.4.3",
-    "scipy>=1.0.0,<1.17.1",
-    "sparse>0.10.0,<0.17.1",
-    "numba>=0.55.0,<0.65.2", # dependency of sparse - manually added to avoid installation issue in uv
+    "numpy>=1.22",
+    "scipy>=1.0.0",
+    "sparse>0.10.0",
+    "numba>=0.55.0", # dependency of sparse - manually added to avoid installation issue in uv
 ]
 
 [project.urls]
@@ -46,18 +46,18 @@ Issues = "https://github.com/cbueth/infomeasure/issues"
 Changelog = "https://infomeasure.readthedocs.io/en/latest/changelog/"
 
 [project.optional-dependencies]
-lint = ["ruff>=0.15.0,<0.16"]
-test = ["pytest>=6.2.5,<9.2", "pytest-cov>=3,<7.2", "coverage>=6,<7.15"]
+lint = ["ruff>=0.15.0,<1"]
+test = ["pytest>=6.2.5,<10", "pytest-cov>=3,<7", "coverage>=6,<8"]
 doc = [
-    "sphinx>=5,<9.2",
-    "numpydoc>=1.5,<1.11",
-    "myst-nb>=1,<1.5",
-    "sphinx-design>=0.3,<0.8",
-    "sphinx-book-theme>=1,<1.2",
-    "sphinxcontrib-bibtex>=2.3.0,<2.8",
-    "sphinxcontrib-mermaid>=1,<2.1",
-    "sphinx-automodapi>=0.15,<0.23",
-    "matplotlib>=3.5,<3.11",
+    "sphinx>=5,<10",
+    "numpydoc>=1.5,<2",
+    "myst-nb>=1,<2",
+    "sphinx-design>=0.3,<1",
+    "sphinx-book-theme>=1,<2",
+    "sphinxcontrib-bibtex>=2.3.0,<3",
+    "sphinxcontrib-mermaid>=1,<3",
+    "sphinx-automodapi>=0.15,<1",
+    "matplotlib>=3.5,<4",
 ]
 all = ["infomeasure[lint,test,doc]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Changelog = "https://infomeasure.readthedocs.io/en/latest/changelog/"
 
 [project.optional-dependencies]
 lint = ["ruff>=0.15.0,<0.16"]
-test = ["pytest>=6.2.5,<9.1", "pytest-cov>=3,<7.2", "coverage>=6,<7.14"]
+test = ["pytest>=6.2.5,<9.2", "pytest-cov>=3,<7.2", "coverage>=6,<7.14"]
 doc = [
     "sphinx>=5,<9.2",
     "numpydoc>=1.5,<1.11",


### PR DESCRIPTION
This PR removes unnecessarily tight upper version bounds that might block users from installing with newer dependency versions.

Remove redundant upper bounds entirely for runtime dependencies:
- `numpy` is no longer pinned below 2.4.3 (currently capped to 2.4.6 by `numba`, while `2.5.0` is available)
- `scipy` is  no longer pinned below 1.17.1 -> currently 1.18.0
- `sparse` is no longer pinned below 0.17.1 -> currently 0.18.0
- `numba` is  no longer pinned below 0.65.2 -> unchanged at 0.65.1 (numba itself caps numpy appropriately, so our duplicate bound was unnecessary)

The optional dependencies have been bumped to next major version boundary.

#### Relates to 
- #29 