### PR TITLE
fix: support sparse `0.19.0` by converting COO.sum() results to Python scalars

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ keywords:
     - information measures
     - conditional probability
 license: AGPL-3.0-or-later
-version: 0.6.1
+version: 0.6.2
 doi: 10.5281/zenodo.15241810
 date-released: 2026-01-17
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.6.2 (2026-07-06)
+
+- 🐛 **sparse 0.19.0 compatibility**: Fixed a regression introduced in sparse >= 0.17 where `COO.sum()` returns a 0-dimensional COO scalar instead of a Python `int`/`float`. All discrete and ordinal MI, CMI, TE, and CTE estimators now explicitly convert COO sums to Python scalars via `float()`, ensuring compatibility with sparse 0.19.0 while maintaining support for earlier versions.
+
 ## Under Development
 
 - 📈 **Variational MI estimators**: For large datasets, stochastic variational inference {cite:p}`hoffmanStochasticVariationalInference2013` becomes a valid approach to determine variational bounds of mutual information (MI). The following variational estimators for MI are planned:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from datetime import datetime
 project = "infomeasure"
 copyright = f"2024–{datetime.now().year}, infomeasure maintainers"
 author = "Carlson Büth, Acharya Kishor, and Massimiliano Zanin"
-version = "0.6.1"
+version = "0.6.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/infomeasure/_version.py
+++ b/infomeasure/_version.py
@@ -1,3 +1,3 @@
 """infomeasure package version."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/infomeasure/estimators/utils/discrete_interaction_information.py
+++ b/infomeasure/estimators/utils/discrete_interaction_information.py
@@ -4,6 +4,7 @@ mutual information."""
 from collections import Counter
 
 from numpy import (
+    array,
     clip,
     uint64,
     log,
@@ -123,7 +124,7 @@ def _mutual_information_global_nd_int(
     )
 
     # Normalized contingency table (joint probability)
-    contingency_sum = contingency_coo.sum()
+    contingency_sum = float(contingency_coo.sum())
     p_joint = vals / contingency_sum
 
     # Logarithm of the non-zero elements
@@ -133,7 +134,7 @@ def _mutual_information_global_nd_int(
     # Combine the terms to calculate the mutual information
     mi = p_joint * (log_p_joint - log_func(contingency_sum)) + p_joint * log_outer
 
-    misum = mi.sum()  # interaction information can be negative, do not clip
+    misum = float(mi.sum())  # interaction information can be negative, do not clip
     if miller_madow_correction is None:
         return misum
     else:
@@ -163,7 +164,7 @@ def _mutual_information_global_2d_int(
     nzx, nzy, nzv = sp_find(contingency_coo)
 
     # Normalized contingency table (joint probability)
-    contingency_sum = contingency_coo.sum()
+    contingency_sum = float(contingency_coo.sum())
     p_joint = nzv / contingency_sum
     # Marginal probabilities
     pi = ravel(contingency_coo.sum(axis=1))
@@ -294,7 +295,7 @@ def mutual_information_local(
     )
 
     # Normalized contingency table (joint probability)
-    contingency_sum = contingency_coo.sum()
+    contingency_sum = float(contingency_coo.sum())
     # Marginal probabilities
     count_marginals = [
         asnumpy(
@@ -314,7 +315,7 @@ def mutual_information_local(
     # for each row in the input data: log( p(data) / p(data1) * p(data2) )
     p_joint = contingency_coo[indices].data / contingency_sum
     outer = prod(
-        [count[indices[i]] for i, count in enumerate(count_marginals)]
+        array([count[indices[i]] for i, count in enumerate(count_marginals)])
         / contingency_sum,
         axis=0,
     )
@@ -445,7 +446,7 @@ def _conditional_mutual_information_global_nd_int(
     )
 
     # Normalized contingency table (joint probability)
-    contingency_sum = contingency_coo.sum()
+    contingency_sum = float(contingency_coo.sum())
     p_joint = vals / contingency_sum
 
     # Logarithm of the non-zero elements
@@ -457,7 +458,7 @@ def _conditional_mutual_information_global_nd_int(
     )
     # Combine the terms to calculate the mutual information
     mi = p_joint * log_p_joint + p_joint * log_outer
-    misum = mi.sum()  # interaction information can be negative, do not clip
+    misum = float(mi.sum())  # interaction information can be negative, do not clip
     if miller_madow_correction is None:
         return misum
     else:
@@ -526,7 +527,7 @@ def conditional_mutual_information_local(
     )
 
     # Normalized contingency table (joint probability)
-    contingency_sum = contingency_coo.sum()
+    contingency_sum = float(contingency_coo.sum())
     # Marginal-conditioned probabilities
     count_marginals_cond = [
         asnumpy(
@@ -550,7 +551,12 @@ def conditional_mutual_information_local(
     p_joint = contingency_coo[indices].data / contingency_sum
     p_cond = count_cond[indices[-1]] / contingency_sum
     outer = prod(
-        [count[indices[i], indices[-1]] for i, count in enumerate(count_marginals_cond)]
+        array(
+            [
+                count[indices[i], indices[-1]]
+                for i, count in enumerate(count_marginals_cond)
+            ]
+        )
         / contingency_sum,
         axis=0,
     )


### PR DESCRIPTION
## Summary
- Fixes compatibility with **sparse >= 0.17** (tested with **sparse 0.19.0**)
- All 663 CI test failures traced to a single change: in sparse >= 0.17, `COO.sum()` returns a **0-dimensional COO scalar** instead of a Python `int`/`float`
- The fix is minimal and fully backward-compatible with older sparse versions

## Details
Commit `d52338d` removed upper version bounds from `pyproject.toml`, allowing sparse 0.19.0 to be installed. With https://github.com/pydata/sparse/releases/tag/0.19.0 being released, this resulted in 600+ failures of two types:
1. **`TypeError` in local MI/CMI functions**: A Python `list` divided by a COO scalar fails because neither type handles the other's `__array_ufunc__` protocol for `divide`
2. **`RuntimeError` in global MI/CMI functions**: The estimator's type check at `base.py:93` only accepts `ndarray`, `int`, or `float`, not COO

### Changes
`infomeasure/estimators/utils/discrete_interaction_information.py`:
- Added `array` to numpy imports
- `contingency_sum = float(contingency_coo.sum())` in 4 functions (converts COO scalar to Python float)
- `misum = float(mi.sum())` in 2 global functions (converts COO scalar to Python float)
- Wrapped list comprehensions in `array()` for two list/float division sites (required after the float conversion, since Python lists don't support `/` with float)