### PR TITLE
box_size for phase TE

### DIFF
--- a/infomeasure/estimators/mutual_information/kraskov_stoegbauer_grassberger.py
+++ b/infomeasure/estimators/mutual_information/kraskov_stoegbauer_grassberger.py
@@ -52,6 +52,7 @@ class BaseKSGMIEstimator(ABC):
         *data,
         cond=None,
         k: int = 4,
+        boxsize: float = None,
         ksg_id: int = 1,
         noise_level=1e-10,
         minkowski_p=inf,
@@ -109,6 +110,7 @@ class BaseKSGMIEstimator(ABC):
             # Ensure self.cond is a 2D array
             self.cond = assure_2d_data(self.cond)
         self.k = k
+        self.boxsize=boxsize
         if ksg_id not in {1, 2}:
             raise ValueError(f"ksg_id must be 1 or 2, but got {ksg_id}.")
         self.ksg_id = ksg_id
@@ -176,7 +178,7 @@ class KSGMIEstimator(BaseKSGMIEstimator, MutualInformationEstimator):
 
         # Create a KDTree for joint data to find nearest neighbors using the maximum
         # norm
-        tree_joint = KDTree(data_joint)  # default leafsize is 10
+        tree_joint = KDTree(data_joint,boxsize=self.boxsize)  # default leafsize is 10
 
         # Find the k-th nearest neighbor distance for each point in joint space using
         # the maximum norm
@@ -185,7 +187,7 @@ class KSGMIEstimator(BaseKSGMIEstimator, MutualInformationEstimator):
 
         # Create KDTree objects for X and Y to count neighbors in marginal spaces using
         # the maximum norm
-        trees_marginal = [KDTree(var) for var in data]
+        trees_marginal = [KDTree(var,boxsize=self.boxsize) for var in data]
 
         # Count neighbors within k-th nearest neighbor distance in X and Y spaces
         if self.ksg_id == 1:
@@ -289,15 +291,15 @@ class KSGCMIEstimator(BaseKSGMIEstimator, ConditionalMutualInformationEstimator)
         data_joint = column_stack((*data, cond))
 
         # Create KDTree for efficient nearest neighbor search in joint space
-        tree_joint = KDTree(data_joint)
+        tree_joint = KDTree(data_joint,boxsize=self.boxsize)  # default leafsize is 10
 
         # Find k-th nearest neighbor distances in joint space
         distances, _ = tree_joint.query(data_joint, k=self.k + 1, p=self.minkowski_p)
         kth_distances = distances[:, -1]
 
         # Count neighbors within k-th nearest neighbor distance in marginal spaces
-        trees_marginal_cond = [KDTree(column_stack((var, cond))) for var in data]
-        tree_cond = KDTree(cond)
+        trees_marginal_cond = [KDTree(column_stack((var, cond)),boxsize=self.boxsize) for var in data]
+        tree_cond = KDTree(cond,boxsize=self.boxsize)
 
         if self.ksg_id == 1:
             r_strict = nextafter(kth_distances, -inf)

--- a/infomeasure/estimators/transfer_entropy/kraskov_stoegbauer_grassberger.py
+++ b/infomeasure/estimators/transfer_entropy/kraskov_stoegbauer_grassberger.py
@@ -60,6 +60,7 @@ class BaseKSGTEEstimator(ABC):
         *,  # Enforce keyword-only arguments
         cond=None,
         k: int = 4,
+        boxsize: float = None,
         ksg_id: int = 1,
         noise_level=1e-8,
         minkowski_p=inf,
@@ -132,6 +133,7 @@ class BaseKSGTEEstimator(ABC):
                 **kwargs,
             )
         self.k = k
+        self.boxsize=boxsize
         if ksg_id not in {1, 2}:
             raise ValueError(f"ksg_id must be 1 or 2, but got {ksg_id}.")
         self.ksg_id = ksg_id
@@ -206,7 +208,7 @@ class KSGTEEstimator(BaseKSGTEEstimator, TransferEntropyEstimator):
         )
 
         # Create KDTree for efficient nearest neighbor search in joint space
-        tree_joint = KDTree(joint_space_data)
+        tree_joint = KDTree(joint_space_data,boxsize=self.boxsize)
 
         # Find distances to the k-th nearest neighbor in the joint space
         distances, _ = tree_joint.query(
@@ -215,9 +217,9 @@ class KSGTEEstimator(BaseKSGTEEstimator, TransferEntropyEstimator):
         kth_distances = distances[:, -1]  # get last column with k-th distances
 
         # Count points in marginal spaces
-        tree_dest_past_present = KDTree(marginal_2_space_data)
-        tree_source_past_dest_past = KDTree(marginal_1_space_data)
-        tree_dest_past = KDTree(data_dest_past_embedded)
+        tree_dest_past_present = KDTree(marginal_2_space_data,boxsize=self.boxsize)
+        tree_source_past_dest_past = KDTree(marginal_1_space_data,boxsize=self.boxsize)
+        tree_dest_past = KDTree(data_dest_past_embedded,boxsize=self.boxsize)
 
         if self.ksg_id == 1:
             r_strict = nextafter(kth_distances, -inf)
@@ -353,7 +355,7 @@ class KSGCTEEstimator(BaseKSGTEEstimator, ConditionalTransferEntropyEstimator):
         )
 
         # Create KDTree for efficient nearest neighbor search in joint space
-        tree_joint = KDTree(joint_space_data)
+        tree_joint = KDTree(joint_space_data,boxsize=self.boxsize)
 
         # Find distances to the k-th nearest
         distances, _ = tree_joint.query(
@@ -362,9 +364,9 @@ class KSGCTEEstimator(BaseKSGTEEstimator, ConditionalTransferEntropyEstimator):
         kth_distances = distances[:, -1]
 
         # Count points in marginal spaces
-        tree_cond_dest_past_present = KDTree(marginal_2_space_data)
-        tree_source_past_cond_dest_past = KDTree(marginal_1_space_data)
-        tree_dest_past_cond = KDTree(data_dest_past_embedded)
+        tree_cond_dest_past_present = KDTree(marginal_2_space_data,boxsize=self.boxsize)
+        tree_source_past_cond_dest_past = KDTree(marginal_1_space_data,boxsize=self.boxsize)
+        tree_dest_past_cond = KDTree(data_dest_past_embedded,boxsize=self.boxsize)
 
         if self.ksg_id == 1:
             r_strict = nextafter(kth_distances, -inf)


### PR DESCRIPTION
added a new feature for the KSG estimator for mutual information and transfer entropy. By being able to pass the argument boxsize we wrap up the space so that all variables have periodic conditions at [0,boxsize]. 

Unfortunately it can handle either no periodic conditions or the same periodic condition variable. Rescaling differently each of your variables before passing them in the estimators maybe its possible to account for different periodic conditions. It would be nice if this could be further elaborated in the future,